### PR TITLE
Update Transformation Template

### DIFF
--- a/digital_ingest_notifications_template.yaml
+++ b/digital_ingest_notifications_template.yaml
@@ -75,7 +75,7 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
@@ -86,7 +86,7 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'sqs:ReceiveMessage'
                   - 'sqs:DeleteMessage'
                   - 'sqs:GetQueueAttributes'
@@ -96,7 +96,7 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'sns:Publish'
                 Resource:
                   - !Ref EventsTopicArn
@@ -141,6 +141,6 @@ Resources:
       FunctionName: !GetAtt DigitalIngestNotificationsFunction.Arn
 
 Outputs:
-  DigitalIngesteNotificationsFunction:
+  DigitalIngestNotificationsFunction:
     Description: 'Digital Ingest Notifications Lambda Function ARN'
     Value: !GetAtt DigitalIngestNotificationsFunction.Arn

--- a/digital_ingest_pipeline_template.yaml
+++ b/digital_ingest_pipeline_template.yaml
@@ -173,7 +173,7 @@ Resources:
         EfsId: !Ref TemporaryStorage
         EfsAccessPointId: !Ref TemporaryStorageAccessPoint
         EfsRootPath: '/efs'
-        # What else?
+        # TODO: Add additional parameters: clarify which parameters are necessary from digital-ingest-transformation_template.yml
 
   # SNS topic
   DigitalIngestTopic:

--- a/digital_ingest_pipeline_template.yaml
+++ b/digital_ingest_pipeline_template.yaml
@@ -173,7 +173,7 @@ Resources:
         EfsId: !Ref TemporaryStorage
         EfsAccessPointId: !Ref TemporaryStorageAccessPoint
         EfsRootPath: '/efs'
-        # TODO: Add additional parameters: clarify which parameters are necessary from digital-ingest-transformation_template.yml
+        # TODO: Add additional parameters - clarify which parameters are necessary from digital_ingest_transformation_template.yml
 
   # SNS topic
   DigitalIngestTopic:

--- a/digital_ingest_pipeline_template.yaml
+++ b/digital_ingest_pipeline_template.yaml
@@ -14,7 +14,7 @@ Mappings:
       prod: digital_ingest_pipeline
     SecurityGroup:
       dev: "sg-0f98d77d7bb7b4ce6"
-      prod: "sg-0a568e8a6ff39b710" 
+      prod: "sg-0a568e8a6ff39b710"
     Subnet:
       dev: "subnet-098df07b0ab91cb1d"
       prod: "subnet-02e68cd17b1abfc14"
@@ -33,7 +33,7 @@ Mappings:
     DigitizationEfsId:
       dev: "fs-4ecb5eae"
       prod: "fs-b9197b5a"
-    DigitizationEfsAccessPointId: 
+    DigitizationEfsAccessPointId:
       dev: "fsap-0d530b00165a90a27"
       prod: "" # TODO
     DigitizationRootPath:
@@ -44,7 +44,7 @@ Mappings:
       prod: "src"
     DigitizationUrl:
       dev: "https://zodiac.dev.rockarch.org:8012"
-      prod: "https://zodiac.rockarch.org:8012"  
+      prod: "https://zodiac.rockarch.org:8012"
 
 Parameters:
   Environment:
@@ -66,7 +66,7 @@ Resources:
           Value: !Ref Environment
         - Key: Application
           Value: digital-ingest-temporary-storage
-      LifecyclePolicies: 
+      LifecyclePolicies:
         - TransitionToIA: AFTER_30_DAYS
       PerformanceMode: generalPurpose
       ThroughputMode: elastic
@@ -90,7 +90,7 @@ Resources:
           OwnerUid: "1000"
           Permissions: "755"
         Path: "/digital-ingest"
-  
+
   # ECS Cluster
   DigitalIngestECSCluster:
     Type: AWS::ECS::Cluster
@@ -109,7 +109,7 @@ Resources:
     Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL:
-        !Join ["/", 
+        !Join ["/",
           [
           "https://s3.amazonaws.com",
           !FindInMap [DeployResources, CloudFormationBucket, !Ref Environment],
@@ -159,7 +159,7 @@ Resources:
     Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL:
-        !Join ["/", 
+        !Join ["/",
           [
           "https://s3.amazonaws.com",
           !FindInMap [DeployResources, CloudFormationBucket, !Ref Environment],
@@ -173,14 +173,14 @@ Resources:
         EfsId: !Ref TemporaryStorage
         EfsAccessPointId: !Ref TemporaryStorageAccessPoint
         EfsRootPath: '/efs'
-        # TODO: Add additional parameters - clarify which parameters are necessary from digital_ingest_transformation_template.yml
+        EventsTopicArn: !Ref DigitalIngestTopic
 
   # SNS topic
   DigitalIngestTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: digital-ingest-notifications    
-  
+      TopicName: digital-ingest-notifications
+
   # SQS Notifications Queue
   DigitalIngestNotificationsQueue:
     Type: AWS::SQS::Queue
@@ -220,13 +220,13 @@ Resources:
       Endpoint: !GetAtt DigitalIngestTriggerQueue.Arn
       FilterPolicy: '"requested_status": [{"exists": true}]'
       FilterPolicyScope: MessageAttributes
-  
+
   # Notifications Lambda
   NotificationsLambda:
     Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL:
-        !Join ["/", 
+        !Join ["/",
           [
           "https://s3.amazonaws.com",
           !FindInMap [DeployResources, CloudFormationBucket, !Ref Environment],
@@ -246,7 +246,7 @@ Resources:
     Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL:
-        !Join ["/", 
+        !Join ["/",
           [
           "https://s3.amazonaws.com",
           !FindInMap [DeployResources, CloudFormationBucket, !Ref Environment],
@@ -268,7 +268,7 @@ Resources:
     Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL:
-        !Join ["/", 
+        !Join ["/",
           [
           "https://s3.amazonaws.com",
           !FindInMap [DeployResources, CloudFormationBucket, !Ref Environment],

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -29,10 +29,6 @@ Parameters:
   EfsRootPath:
     Type: String
     Description: Root path at which EFS is mounted.
-  #Is this needed?
-  PackageID: 
-    Type: String
-    Description: String representation of the package identifier
   EventsTopicArn:
     Type: String
     Description: ARN for events SNS Topic
@@ -81,7 +77,6 @@ Resources:
 
   TransformationUser:
     Type: AWS::IAM::User
-    UserName: TransformationUser
 
   TransformationUserAccessKey:
     Type: AWS::IAM::AccessKey
@@ -160,9 +155,6 @@ Resources:
               Value: !GetAtt TransformationSsmRole.Arn
             - Name: AWS_SNS_TOPIC
               Value: !Ref EventsTopicArn
-            #Is this needed?
-            - Name: PACKAGE_ID
-              Value: !Ref PackageID
           Tags:
             - Key: Environment
               Value: !Ref ApplicationEnvironment

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -21,54 +21,6 @@ Parameters:
   ApplicationName:
     Type: String
     Description: Name of the application to be deployed.
-  ArchivematicaSSAPIKey:
-    Type: String
-    Description: API Key for Archivematica Storage Service
-  ArchivematicaSSUserName:
-    Type: String
-    Description: Archivematica Storage Service Username
-  ArchivematicaSSUrl: 
-    Type: String
-    Description: URL for the Archivematica Storage Service
-  ZodiacBaseurl:
-    Type: String
-    Description: BaseURL for the Zodiac Backend
-  ASBaseurl:
-    Type: String
-    Description: BaseURL for the ArchivesSpace Backend
-  ASUsername:
-    Type: String
-    Description: ArchivesSpace Username
-  ASPassword:
-    Type: String
-    Description: ArchivesSpace Password
-  ASRepoID:
-    Type: Number
-    Description: ArchivesSpace Repository ID
-  AuroraBaseurl:
-    Type: String
-    Description: Aurora BaseURL
-  AuroraOauthClientBaseurl:
-    Type: String
-    Description: Aurora OAuth Client BaseURL
-  AuroraOauthClientID:
-    Type: String
-    Description: Aurora OAuth Client ID
-  AuroraOauthClientSecret:
-    Type: String
-    Description: Aurora OAuth Client Secret
-  AuroraAccessionStartedStatus:
-    Type: String
-    Description: Status of Aurora Accession at start
-  AuroraPackageCompleteStatus:
-    Type: String
-    Description: Status of Aurora Accession at completion
-  IIIFManifestBaseurl:
-    Type: String
-    Description: BaseURL for the IIIF manifest
-  DownloadBaseurl:
-    Type: String
-    Description: BaseURL to download the object
   # Elastic File System (EFS) parameters for temporary storage of files as they are transformed and moved through the pipeline
   EfsId:
     Type: String
@@ -214,30 +166,16 @@ Resources:
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
           Environment:
-            Variables:
-              ENV: !Ref ApplicationEnvironment
-              SNS_ROLE_ARN: !GetAtt TransformationSnsRole.Arn
-              SSM_ROLE_ARN: !GetAtt TransformationSsmRole.Arn
-              SNS_TOPIC: !Ref EventsTopicArn
-              PACKAGE_ID: !Ref PackageID
-              ARCHIVEMATICA_SS_API_KEY: !Ref ArchivematicaSSAPIKey
-              ARCHIVEMATICA_SS_USER_NAME: !Ref ArchivematicaSSUserName
-              ARCHIVEMATICA_SS_URL: !Ref ArchivematicaSSUrl
-              ZODIAC_BASEURL: !Ref ZodiacBaseurl
-              AS_BASEURL: !Ref ASBaseurl
-              AS_USERNAME: !Ref ASUsername
-              AS_PASSWORD: !Ref ASPassword
-              AS_REPO_ID: !Ref ASRepoID
-              AURORA_BASEURL: !Ref AuroraBaseurl
-              AURORA_OAUTH_CLIENT_BASEURL: !Ref AuroraOauthClientBaseurl
-              AURORA_OAUTH_CLIENT_ID: !Ref AuroraOauthClientID
-              AURORA_OAUTH_CLIENT_SECRET: !Ref AuroraOauthClientSecret
-              AURORA_ACCESSION_STARTED_STATUS: !Ref AuroraAccessionStartedStatus
-              AURORA_PACKAGE_COMPLETE_STATUS: !Ref AuroraPackageCompleteStatus
-              IIIF_MANIFEST_BASEURL: !Ref IIIFManifestBaseurl
-              DOWNLOAD_BASEURL: !Ref DownloadBaseurl
-              APP_CONFIG_PATH: !Ref ApplicationName
-              AWS_REGION: !Ref AWS::Region
+            - Name: ENV
+              Value: !Ref ApplicationEnvironment
+            - Name: AWS_SNS_ROLE_ARN
+              Value: !GetAtt TransformationSnsRole.Arn
+            - Name: AWS_SSM_ROLE_ARN
+              Value: !GetAtt TransformationSsmRole.Arn
+            - Name: AWS_SNS_TOPIC
+              Value: !Ref EventsTopicArn
+            - Name: PACKAGE_ID
+              Value: !Ref PackageID
           Tags:
             - Key: Environment
               Value: !Ref ApplicationEnvironment

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -17,56 +17,56 @@ Parameters:
     AllowedValues:
       - dev
       - prod
-    # Do we need a default defined like in digital_ingest_pipeline_template.yml?
+    default: dev
   ApplicationName:
     Type: String
     Description: Name of the application to be deployed.
-  ARCHIVEMATICA_SS_API_KEY:
+  ArchivematicaSSAPIKey:
     Type: String
     Description: API Key for Archivematica Storage Service
-  ARCHIVEMATICA_SS_USER_NAME:
+  ArchivematicaSSUserName:
     Type: String
     Description: Archivematica Storage Service Username
-  ARCHIVEMATICA_SS_URL: 
+  ArchivematicaSSUrl: 
     Type: String
     Description: URL for the Archivematica Storage Service
-  ZODIAC_BASEURL:
+  ZodiacBaseurl:
     Type: String
     Description: BaseURL for the Zodiac Backend
-  AS_BASEURL:
+  ASBaseurl:
     Type: String
     Description: BaseURL for the ArchivesSpace Backend
-  AS_USERNAME:
+  ASUsername:
     Type: String
     Description: ArchivesSpace Username
-  AS_PASSWORD:
+  ASPassword:
     Type: String
     Description: ArchivesSpace Password
-  AS_REPO_ID:
+  ASRepoID:
     Type: Number
     Description: ArchivesSpace Repository ID
-  AURORA_BASEURL:
+  AuroraBaseurl:
     Type: String
     Description: Aurora BaseURL
-  AURORA_OAUTH_CLIENT_BASEURL:
+  AuroraOauthClientBaseurl:
     Type: String
     Description: Aurora OAuth Client BaseURL
-  AURORA_OAUTH_CLIENT_ID:
+  AuroraOauthClientID:
     Type: String
     Description: Aurora OAuth Client ID
-  AURORA_OAUTH_CLIENT_SECRET:
+  AuroraOauthClientSecret:
     Type: String
     Description: Aurora OAuth Client Secret
-  AURORA_ACCESSION_STARTED_STATUS:
+  AuroraAccessionStartedStatus:
     Type: String
     Description: Status of Aurora Accession at start
-  AURORA_PACKAGE_COMPLETE_STATUS:
+  AuroraPackageCompleteStatus:
     Type: String
     Description: Status of Aurora Accession at completion
-  IIIF_MANIFEST_BASEURL:
+  IIIFManifestBaseurl:
     Type: String
     Description: BaseURL for the IIIF manifest
-  DOWNLOAD_BASEURL:
+  DownloadBaseurl:
     Type: String
     Description: BaseURL to download the object
   # Elastic File System (EFS) parameters for temporary storage of files as they are transformed and moved through the pipeline
@@ -93,6 +93,7 @@ Parameters:
     Description: Name of S3 bucket to which packaged files should be delivered.
 
   # Elastic File System (EFS) parameters for digitization delivery for packages that are not from Aurora
+  # These are being called by the EFS resources, but not sure if that resource is necessary for this application
   DigitizationEfsId:
     Type: String
     Description: Identifier for digitization delivery EFS.
@@ -108,7 +109,9 @@ Parameters:
   DigitizationUrl:
     Type: String
     Description: URL to post to to trigger further processing for packages of digitized content.
-
+  PackageID:
+    Type: String
+    Description: String representation of the package identifier
   EventsTopicArn:
     Type: String
     Description: ARN for events SNS Topic
@@ -231,24 +234,23 @@ Resources:
               SNS_ROLE_ARN: !GetAtt TransformationRole.Arn
               SSM_ROLE_ARN: !GetAtt TransformationRole.Arn
               SNS_TOPIC: !Ref EventsTopicArn
-              # Currently don't know where this comes from/what it is
               PACKAGE_ID: !Ref PackageID
-              ARCHIVEMATICA_SS_API_KEY: !Ref ARCHIVEMATICA_SS_API_KEY
-              ARCHIVEMATICA_SS_USER_NAME: !Ref ARCHIVEMATICA_SS_USER_NAME
-              ARCHIVEMATICA_SS_URL: !Ref ARCHIVEMATICA_SS_URL
-              ZODIAC_BASEURL: !Ref ZODIAC_BASEURL
-              AS_BASEURL: !Ref AS_BASEURL
-              AS_USERNAME: !Ref AS_USERNAME
-              AS_PASSWORD: !Ref AS_PASSWORD
-              AS_REPO_ID: !Ref AS_REPO_ID
-              AURORA_BASEURL: !Ref AURORA_BASEURL
-              AURORA_OAUTH_CLIENT_BASEURL: !Ref AURORA_OAUTH_CLIENT_BASEURL
-              AURORA_OAUTH_CLIENT_ID: !Ref AURORA_OAUTH_CLIENT_ID
-              AURORA_OAUTH_CLIENT_SECRET: !Ref AURORA_OAUTH_CLIENT_SECRET
-              AURORA_ACCESSION_STARTED_STATUS: !Ref AURORA_ACCESSION_STARTED_STATUS
-              AURORA_PACKAGE_COMPLETE_STATUS: !Ref AURORA_PACKAGE_COMPLETE_STATUS
-              IIIF_MANIFEST_BASEURL: !Ref IIIF_MANIFEST_BASEURL
-              DOWNLOAD_BASEURL: !Ref DOWNLOAD_BASEURL
+              ARCHIVEMATICA_SS_API_KEY: !Ref ArchivematicaSSAPIKey
+              ARCHIVEMATICA_SS_USER_NAME: !Ref ArchivematicaSSUserName
+              ARCHIVEMATICA_SS_URL: !Ref ArchivematicaSSUrl
+              ZODIAC_BASEURL: !Ref ZodiacBaseurl
+              AS_BASEURL: !Ref ASBaseurl
+              AS_USERNAME: !Ref ASUsername
+              AS_PASSWORD: !Ref ASPassword
+              AS_REPO_ID: !Ref ASRepoID
+              AURORA_BASEURL: !Ref AuroraBaseurl
+              AURORA_OAUTH_CLIENT_BASEURL: !Ref AuroraOauthClientBaseurl
+              AURORA_OAUTH_CLIENT_ID: !Ref AuroraOauthClientID
+              AURORA_OAUTH_CLIENT_SECRET: !Ref AuroraOauthClientSecret
+              AURORA_ACCESSION_STARTED_STATUS: !Ref AuroraAccessionStartedStatus
+              AURORA_PACKAGE_COMPLETE_STATUS: !Ref AuroraPackageCompleteStatus
+              IIIF_MANIFEST_BASEURL: !Ref IIIFManifestBaseurl
+              DOWNLOAD_BASEURL: !Ref DownloadBaseurl
               APP_CONFIG_PATH: !Ref ApplicationName
               AWS_REGION: !Ref AWS::Region
           Tags:

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -221,18 +221,18 @@ Resources:
     Properties:
       Cpu: "1024"
       Memory: "3072"
-      SNS_ROLE_ARN: !GetAtt TransformationRole.Arn
-      SSM_ROLE_ARN: !GetAtt TransformationRole.Arn
-      SNS_TOPIC: !Ref EventsTopicArn
-      # Currently don't know where this comes from/what it is
-      PACKAGE_ID: !Ref PackageID
       ContainerDefinitions:
         - Name: !Ref ApplicationName
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
           Environment:
             Variables:
-              Env: !Ref ApplicationEnvironment
+              ENV: !Ref ApplicationEnvironment
+              SNS_ROLE_ARN: !GetAtt TransformationRole.Arn
+              SSM_ROLE_ARN: !GetAtt TransformationRole.Arn
+              SNS_TOPIC: !Ref EventsTopicArn
+              # Currently don't know where this comes from/what it is
+              PACKAGE_ID: !Ref PackageID
               ARCHIVEMATICA_SS_API_KEY: !Ref ARCHIVEMATICA_SS_API_KEY
               ARCHIVEMATICA_SS_USER_NAME: !Ref ARCHIVEMATICA_SS_USER_NAME
               ARCHIVEMATICA_SS_URL: !Ref ARCHIVEMATICA_SS_URL

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -39,19 +39,6 @@ Parameters:
     Description: ARN for events SNS Topic
 
 Resources:
-  # I think we need this, but could be wrong.
-  SnsTopicParam:
-    Type: AWS::SSM::Parameter
-    Properties: 
-      AllowedPattern: "^[A-Za-z0-9\\-\\_]+$"
-      Description: ARN for SNS topic to send messages to.
-      Name: !Sub /${ApplicationEnvironment}/${ApplicationName}/SNS_TOPIC
-      Tags: 
-        Environment: !Ref ApplicationEnvironment
-        Application: !Ref ApplicationName
-      Type: String
-      Value: !Ref EventsTopicArn
-
   # An ECS task definition that defines the container
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -116,7 +103,7 @@ Resources:
               - 'sts:AssumeRole'
       Description: 'Allows user to send SNS messages.'
       Policies:
-        - PolicyName: TransformationSNSPolicy
+        - PolicyName: TransformationSnsPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -140,7 +127,7 @@ Resources:
               - 'sts:AssumeRole'
       Description: 'Allows access to SSM parameters.'
       Policies:
-        - PolicyName: TransformationSSMPolicy
+        - PolicyName: TransformationSsmPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -108,6 +108,7 @@ Resources:
 
   TransformationUser:
     Type: AWS::IAM::User
+    UserName: TransformationUser
 
   TransformationUserAccessKey:
     Type: AWS::IAM::AccessKey

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -21,7 +21,54 @@ Parameters:
   ApplicationName:
     Type: String
     Description: Name of the application to be deployed.
-
+  ARCHIVEMATICA_SS_API_KEY:
+    Type: String
+    Description: API Key for Archivematica Storage Service
+  ARCHIVEMATICA_SS_USER_NAME:
+    Type: String
+    Description: Archivematica Storage Service Username
+  ARCHIVEMATICA_SS_URL: 
+    Type: String
+    Description: URL for the Archivematica Storage Service
+  ZODIAC_BASEURL:
+    Type: String
+    Description: BaseURL for the Zodiac Backend
+  AS_BASEURL:
+    Type: String
+    Description: BaseURL for the ArchivesSpace Backend
+  AS_USERNAME:
+    Type: String
+    Description: ArchivesSpace Username
+  AS_PASSWORD:
+    Type: String
+    Description: ArchivesSpace Password
+  AS_REPO_ID:
+    Type: Number
+    Description: ArchivesSpace Repository ID
+  AURORA_BASEURL:
+    Type: String
+    Description: Aurora BaseURL
+  AURORA_OAUTH_CLIENT_BASEURL:
+    Type: String
+    Description: Aurora OAuth Client BaseURL
+  AURORA_OAUTH_CLIENT_ID:
+    Type: String
+    Description: Aurora OAuth Client ID
+  AURORA_OAUTH_CLIENT_SECRET:
+    Type: String
+    Description: Aurora OAuth Client Secret
+  AURORA_ACCESSION_STARTED_STATUS:
+    Type: String
+    Description: Status of Aurora Accession at start
+  AURORA_PACKAGE_COMPLETE_STATUS:
+    Type: String
+    Description: Status of Aurora Accession at completion
+  IIIF_MANIFEST_BASEURL:
+    Type: String
+    Description: BaseURL for the IIIF manifest
+  DOWNLOAD_BASEURL:
+    Type: String
+    Description: BaseURL to download the object
   # Elastic File System (EFS) parameters for temporary storage of files as they are transformed and moved through the pipeline
   EfsId:
     Type: String
@@ -40,6 +87,7 @@ Parameters:
     Description: Location in EFS mount at which files are unpacked.
 
   # S3 bucket where transformed files are stored
+  # Not sure this is necessary. It's not being used anywhere AFAIK
   SourceBucketName:
     Type: String
     Description: Name of S3 bucket to which packaged files should be delivered.
@@ -60,11 +108,25 @@ Parameters:
   DigitizationUrl:
     Type: String
     Description: URL to post to to trigger further processing for packages of digitized content.
+
   EventsTopicArn:
     Type: String
     Description: ARN for events SNS Topic
 
 Resources:
+  # I think we need this, but could be wrong.
+  SnsTopicParam:
+    Type: AWS::SSM::Parameter
+    Properties: 
+      AllowedPattern: "^[A-Za-z0-9\\-\\_]+$"
+      Description: ARN for SNS topic to send messages to.
+      Name: !Sub /${ApplicationEnvironment}/${ApplicationName}/SNS_TOPIC
+      Tags: 
+        Environment: !Ref ApplicationEnvironment
+        Application: !Ref ApplicationName
+      Type: String
+      Value: !Ref EventsTopicArn
+
   # An ECS task definition that defines the container
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -129,6 +191,15 @@ Resources:
               - 'sts:AssumeRole'
       Description: 'Allows access to SSM parameters.'
       Policies:
+        - PolicyName: TransformationSNSPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - 'sns:Publish'
+                Resource:
+                  - !Ref EventsTopicArn
         - PolicyName: TransformationSSMPolicy
           PolicyDocument:
             Version: '2012-10-17'
@@ -150,31 +221,41 @@ Resources:
     Properties:
       Cpu: "1024"
       Memory: "3072"
+      SNS_ROLE_ARN: !GetAtt TransformationRole.Arn
+      SSM_ROLE_ARN: !GetAtt TransformationRole.Arn
+      SNS_TOPIC: !Ref EventsTopicArn
+      # Currently don't know where this comes from/what it is
+      PACKAGE_ID: !Ref PackageID
       ContainerDefinitions:
         - Name: !Ref ApplicationName
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
           Environment:
-            - Name: ENV
+            Variables:
+              Env: !Ref ApplicationEnvironment
+              ARCHIVEMATICA_SS_API_KEY: !Ref ARCHIVEMATICA_SS_API_KEY
+              ARCHIVEMATICA_SS_USER_NAME: !Ref ARCHIVEMATICA_SS_USER_NAME
+              ARCHIVEMATICA_SS_URL: !Ref ARCHIVEMATICA_SS_URL
+              ZODIAC_BASEURL: !Ref ZODIAC_BASEURL
+              AS_BASEURL: !Ref AS_BASEURL
+              AS_USERNAME: !Ref AS_USERNAME
+              AS_PASSWORD: !Ref AS_PASSWORD
+              AS_REPO_ID: !Ref AS_REPO_ID
+              AURORA_BASEURL: !Ref AURORA_BASEURL
+              AURORA_OAUTH_CLIENT_BASEURL: !Ref AURORA_OAUTH_CLIENT_BASEURL
+              AURORA_OAUTH_CLIENT_ID: !Ref AURORA_OAUTH_CLIENT_ID
+              AURORA_OAUTH_CLIENT_SECRET: !Ref AURORA_OAUTH_CLIENT_SECRET
+              AURORA_ACCESSION_STARTED_STATUS: !Ref AURORA_ACCESSION_STARTED_STATUS
+              AURORA_PACKAGE_COMPLETE_STATUS: !Ref AURORA_PACKAGE_COMPLETE_STATUS
+              IIIF_MANIFEST_BASEURL: !Ref IIIF_MANIFEST_BASEURL
+              DOWNLOAD_BASEURL: !Ref DOWNLOAD_BASEURL
+              APP_CONFIG_PATH: !Ref ApplicationName
+              AWS_REGION: !Ref AWS::Region
+          Tags:
+            - Key: Environment
               Value: !Ref ApplicationEnvironment
-            - Name: APP_CONFIG_PATH
+            - Key: Application
               Value: !Ref ApplicationName
-            - Name: AWS_REGION
-              Value: !Ref AWS::Region
-            - Name: AWS_ROLE_ARN
-              Value: !GetAtt DigitizedAvPackagingRole.Arn
-            - Name: STORAGE_DIR
-              Value: !Sub '${EfsRootPath}/${StoragePath}'
-            - Name: TMP_DIR
-              Value: !Sub '${EfsRootPath}/${TemporaryPath}'
-            - Name: DIGITIZATION_URL
-              Value: !Ref DigitizationUrl
-            - Name: DIGITIZATION_PATH
-              Value: !Sub '${DigitizationRootPath}/${DigitizationPath}'
-            - Name: AWS_SOURCE_BUCKET
-              Value: !Ref SourceBucketName
-            - Name: AWS_SNS_TOPIC
-              Value: !Ref EventsTopicArn
 
           MountPoints:
             - SourceVolume: efs

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -6,7 +6,6 @@ Description: >
   Archival Objects, and Digital Objects in ArchivesSpace.
 
 Parameters:
-# The AWS account that hosts the Amazon Elastic Container Registry (ECR) repository
   ContainerAccountId:
     Type: String
     Description: Account ID under which container repository is located.
@@ -17,11 +16,10 @@ Parameters:
     AllowedValues:
       - dev
       - prod
-    default: dev
+    Default: dev
   ApplicationName:
     Type: String
     Description: Name of the application to be deployed.
-  # Elastic File System (EFS) parameters for temporary storage of files as they are transformed and moved through the pipeline
   EfsId:
     Type: String
     Description: Identifier for temporary storage EFS.
@@ -31,7 +29,7 @@ Parameters:
   EfsRootPath:
     Type: String
     Description: Root path at which EFS is mounted.
-  PackageID:
+  PackageID: #Is this needed?
     Type: String
     Description: String representation of the package identifier
   EventsTopicArn:
@@ -52,7 +50,6 @@ Resources:
       Type: String
       Value: !Ref EventsTopicArn
 
-  # An ECS task definition that defines the container
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -166,7 +163,7 @@ Resources:
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
           Environment:
-            - Name: ENV
+            - Name: ENVIRONMENT
               Value: !Ref ApplicationEnvironment
             - Name: AWS_SNS_ROLE_ARN
               Value: !GetAtt TransformationSnsRole.Arn
@@ -174,7 +171,7 @@ Resources:
               Value: !GetAtt TransformationSsmRole.Arn
             - Name: AWS_SNS_TOPIC
               Value: !Ref EventsTopicArn
-            - Name: PACKAGE_ID
+            - Name: PACKAGE_ID  #Is this needed?
               Value: !Ref PackageID
           Tags:
             - Key: Environment

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: 2010-09-09
 Description: >
   digital-ingest-transformation
 
@@ -79,36 +79,6 @@ Parameters:
   EfsRootPath:
     Type: String
     Description: Root path at which EFS is mounted.
-  StoragePath:
-    Type: String
-    Description: Location in EFS mount at which source files are stored.
-  TemporaryPath:
-    Type: String
-    Description: Location in EFS mount at which files are unpacked.
-
-  # S3 bucket where transformed files are stored
-  # Not sure this is necessary. It's not being used anywhere AFAIK
-  SourceBucketName:
-    Type: String
-    Description: Name of S3 bucket to which packaged files should be delivered.
-
-  # Elastic File System (EFS) parameters for digitization delivery for packages that are not from Aurora
-  # These are being called by the EFS resources, but not sure if that resource is necessary for this application
-  DigitizationEfsId:
-    Type: String
-    Description: Identifier for digitization delivery EFS.
-  DigitizationEfsAccessPointId:
-    Type: String
-    Description: Identifier for digitization delivery EFS access point.
-  DigitizationRootPath:
-    Type: String
-    Description: Root path for digitized delivery.
-  DigitizationPath:
-    Type: String
-    Description: Path to deliver packages of digitized content for further processing.
-  DigitizationUrl:
-    Type: String
-    Description: URL to post to to trigger further processing for packages of digitized content.
   PackageID:
     Type: String
     Description: String representation of the package identifier
@@ -180,7 +150,31 @@ Resources:
     Properties:
       UserName: !Ref TransformationUser
 
-  TransformationRole:
+  TransformationSnsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt TransformationUser.Arn
+            Action:
+              - 'sts:AssumeRole'
+      Description: 'Allows user to send SNS messages.'
+      Policies:
+        - PolicyName: TransformationSNSPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - 'sns:Publish'
+                Resource:
+                  - !Ref EventsTopicArn
+
+  TransformationSsmRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -194,15 +188,6 @@ Resources:
               - 'sts:AssumeRole'
       Description: 'Allows access to SSM parameters.'
       Policies:
-        - PolicyName: TransformationSNSPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: 
-                  - 'sns:Publish'
-                Resource:
-                  - !Ref EventsTopicArn
         - PolicyName: TransformationSSMPolicy
           PolicyDocument:
             Version: '2012-10-17'
@@ -231,8 +216,8 @@ Resources:
           Environment:
             Variables:
               ENV: !Ref ApplicationEnvironment
-              SNS_ROLE_ARN: !GetAtt TransformationRole.Arn
-              SSM_ROLE_ARN: !GetAtt TransformationRole.Arn
+              SNS_ROLE_ARN: !GetAtt TransformationSnsRole.Arn
+              SSM_ROLE_ARN: !GetAtt TransformationSsmRole.Arn
               SNS_TOPIC: !Ref EventsTopicArn
               PACKAGE_ID: !Ref PackageID
               ARCHIVEMATICA_SS_API_KEY: !Ref ArchivematicaSSAPIKey
@@ -263,9 +248,6 @@ Resources:
             - SourceVolume: efs
               ContainerPath: !Ref EfsRootPath
               ReadOnly: false
-            - SourceVolume: digitization
-              ContainerPath: !Ref DigitizationRootPath
-              ReadOnly: false
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -288,14 +270,6 @@ Resources:
             TransitEncryption: ENABLED
             AuthorizationConfig:
               AccessPointId: !Ref EfsAccessPointId
-              IAM: DISABLED
-        - Name: digitization
-          EFSVolumeConfiguration:
-            FilesystemID: !Ref DigitizationEfsId
-            RootDirectory: /
-            TransitEncryption: ENABLED
-            AuthorizationConfig:
-              AccessPointId: !Ref DigitizationEfsAccessPointId
               IAM: DISABLED
 
 Outputs:

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -1,11 +1,12 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
-  Aquarius
+  digital-ingest-transformation
 
-  Transforms data data from Aurora and makes Accessions, 
+  Transforms data from Aurora and makes Accessions,
   Archival Objects, and Digital Objects in ArchivesSpace.
 
 Parameters:
+# The AWS account that hosts the Amazon Elastic Container Registry (ECR) repository
   ContainerAccountId:
     Type: String
     Description: Account ID under which container repository is located.
@@ -16,9 +17,12 @@ Parameters:
     AllowedValues:
       - dev
       - prod
+    # Do we need a default defined like in digital_ingest_pipeline_template.yml?
   ApplicationName:
     Type: String
     Description: Name of the application to be deployed.
+
+  # Elastic File System (EFS) parameters for temporary storage of files as they are transformed and moved through the pipeline
   EfsId:
     Type: String
     Description: Identifier for temporary storage EFS.
@@ -34,9 +38,13 @@ Parameters:
   TemporaryPath:
     Type: String
     Description: Location in EFS mount at which files are unpacked.
+
+  # S3 bucket where transformed files are stored
   SourceBucketName:
     Type: String
     Description: Name of S3 bucket to which packaged files should be delivered.
+
+  # Elastic File System (EFS) parameters for digitization delivery for packages that are not from Aurora
   DigitizationEfsId:
     Type: String
     Description: Identifier for digitization delivery EFS.
@@ -57,6 +65,7 @@ Parameters:
     Description: ARN for events SNS Topic
 
 Resources:
+  # An ECS task definition that defines the container
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -75,72 +84,72 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
-                Resource: 
-                  - !GetAtt AquariusLogGroup.Arn
+                Resource:
+                  - !GetAtt TransformationLogGroup.Arn
         - PolicyName: EcrPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'ecr:BatchCheckLayerAvailability'
                   - 'ecr:GetDownloadUrlForLayer'
                   - 'ecr:BatchGetImage'
-                Resource: 
+                Resource:
                   - !Sub arn:aws:ecr:${AWS::Region}:${ContainerAccountId}:repository/${ApplicationName}
               - Effect: Allow
                 Action:
                   - 'ecr:GetAuthorizationToken'
                 Resource: '*'
 
-  AquariusUser:
+  TransformationUser:
     Type: AWS::IAM::User
 
-  AquariusUserAccessKey:
+  TransformationUserAccessKey:
     Type: AWS::IAM::AccessKey
-    Properties: 
-      UserName: !Ref AquariusUser
+    Properties:
+      UserName: !Ref TransformationUser
 
-  AquariusRole:
+  TransformationRole:
     Type: AWS::IAM::Role
-    Properties: 
+    Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               AWS:
-                - !GetAtt AquariusUser.Arn
+                - !GetAtt TransformationUser.Arn
             Action:
               - 'sts:AssumeRole'
       Description: 'Allows access to SSM parameters.'
       Policies:
-        - PolicyName: AquariusSSMPolicy
+        - PolicyName: TransformationSSMPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 
+                Action:
                   - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApplicationEnvironment}/${ApplicationName}
 
-  AquariusLogGroup:
+  TransformationLogGroup:
     Type: AWS::Logs::LogGroup
-    Properties: 
+    Properties:
       LogGroupName: !Sub "/rac/${ApplicationEnvironment}/digital_ingest/ecs/${ApplicationName}"
       RetentionInDays: 90
-  
-  AquariusEcsTask:
+
+  TransformationEcsTask:
     Type: AWS::ECS::TaskDefinition
-    Properties: 
+    Properties:
       Cpu: "1024"
       Memory: "3072"
-      ContainerDefinitions: 
+      ContainerDefinitions:
         - Name: !Ref ApplicationName
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
@@ -176,7 +185,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              "awslogs-group": !Ref AquariusLogGroup
+              "awslogs-group": !Ref TransformationLogGroup
               "awslogs-region": !Ref AWS::Region
               "awslogs-stream-prefix": "ecs"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
@@ -187,7 +196,7 @@ Resources:
       RuntimePlatform:
         CpuArchitecture: X86_64
         OperatingSystemFamily: LINUX
-      Volumes: 
+      Volumes:
         - Name: efs
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsId
@@ -206,6 +215,6 @@ Resources:
               IAM: DISABLED
 
 Outputs:
-  AquariusArn:
-    Description: Aquarius ECS Task Definition ARN
-    Value: !Ref AquariusEcsTask
+  TransformationArn:
+    Description: Transformation ECS Task Definition ARN
+    Value: !Ref TransformationEcsTask

--- a/digital_ingest_transformation_template.yaml
+++ b/digital_ingest_transformation_template.yaml
@@ -29,7 +29,8 @@ Parameters:
   EfsRootPath:
     Type: String
     Description: Root path at which EFS is mounted.
-  PackageID: #Is this needed?
+  #Is this needed?
+  PackageID: 
     Type: String
     Description: String representation of the package identifier
   EventsTopicArn:
@@ -151,7 +152,7 @@ Resources:
           Image: !Sub "${ContainerAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ApplicationName}:latest"
           Essential: true
           Environment:
-            - Name: ENVIRONMENT
+            - Name: ENV
               Value: !Ref ApplicationEnvironment
             - Name: AWS_SNS_ROLE_ARN
               Value: !GetAtt TransformationSnsRole.Arn
@@ -159,7 +160,8 @@ Resources:
               Value: !GetAtt TransformationSsmRole.Arn
             - Name: AWS_SNS_TOPIC
               Value: !Ref EventsTopicArn
-            - Name: PACKAGE_ID  #Is this needed?
+            #Is this needed?
+            - Name: PACKAGE_ID
               Value: !Ref PackageID
           Tags:
             - Key: Environment


### PR DESCRIPTION
Update Cloud Formation template for the [transformation service](https://github.com/RockefellerArchiveCenter/digital_ingest_transformation) (formerly Aquarius). 

- Renamed from Aquarius to Transformation
- Added Dev as default for application environment parameter
- Added SSM Role resource
- Updated parameters and resources: removed unnecessary holdovers from copying the Discovery template
- Added `EventsTopicArn` to nested parameters

Question: is Package_ID needed here? We weren't 100% on how that is being handled.
